### PR TITLE
tests: use tomllib/tomli instead of unmaintained toml

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,4 +7,4 @@ iniconfig!=1.1.0,>=1.0.1
 pytest-cov>=2.8.1
 pytest-randomly>=3.7.0
 pytest-timeout>=1.4.2
-toml>=0.10.2
+tomli>=2.0.1; python_version < "3.11"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -7,11 +7,17 @@ from typing import Any, Dict, Iterator, Mapping, NamedTuple, Sequence
 
 # 3rd party
 import pytest
-import toml
 from domdf_python_tools.compat import PYPY37_PLUS
 from domdf_python_tools.paths import PathPlus
 from domdf_python_tools.stringlist import StringList
 from pytest_regressions.file_regression import FileRegressionFixture
+
+if sys.version_info >= (3, 11):
+    # stdlib
+    import tomllib
+else:
+    # 3rd party
+    import tomli as tomllib
 
 # this package
 from coincidence.regressions import (
@@ -100,7 +106,7 @@ some_toml = "[section]\ntable = {a = 1, b = 2, c = 3}"
 						CustomSequence([MappingProxyType({'a': 1})]), id="Nested_CustomSequence_MappingProxyType"
 						),
 				pytest.param(CustomMapping({'a': Count(a=1, b=2, c=3)}), id="Nested_CustomMapping_NamedTuple"),
-				pytest.param(toml.loads(some_toml)["section"]["table"], id="Toml_InlineTableDict"),
+				pytest.param(tomllib.loads(some_toml)["section"]["table"], id="Toml_InlineTableDict"),
 				pytest.param(pathlib.PurePath("/foo/bar/baz"), id="pathlib_purepath"),
 				pytest.param(pathlib.PurePosixPath("/foo/bar/baz"), id="pathlib_pureposixpath"),
 				pytest.param(pathlib.PureWindowsPath(r"c:\foo\bar\baz"), id="pathlib_purewindowspath"),


### PR DESCRIPTION
The toml library is unmaintained upstream. It has been superseded by tomllib in the Python 3.11+ stdlib and the tomli package for older Python versions.